### PR TITLE
Add resource: Statistics Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-193-blue)
+![Resources](https://img.shields.io/badge/resources-194-blue)
 ![Sections](https://img.shields.io/badge/sections-11-purple)
 [![Changelog](https://img.shields.io/badge/changelog-unreleased-lightgrey.svg)](CHANGELOG.md)
 
@@ -32,7 +32,7 @@ This is a curation list, not a code library. Every entry links out to a tool, ch
 | | Section | Resources |
 | :-: | --- | :-: |
 | 📝 | [Exam & Curriculum Prep](#exam--curriculum-prep) | 60 |
-| 📚 | [By Subject](#by-subject) | 71 |
+| 📚 | [By Subject](#by-subject) | 72 |
 | 🗒️ | [Notes & Knowledge Management](#notes--knowledge-management) | 6 |
 | 🧠 | [Flashcards & Spaced Repetition](#flashcards--spaced-repetition) | 4 |
 | ⏰ | [Task, Time & Planning](#task-time--planning) | 4 |
@@ -233,6 +233,7 @@ Flagship picks per subject: mix a strong site, a channel, and a practice tool.
 - **[Khan Academy Statistics and Probability](https://www.khanacademy.org/math/statistics-probability)** - Free lessons and practice across statistics and probability (free).
 - **[OpenIntro Statistics](https://www.openintro.org/book/os/)** - Free, open-source statistics textbook used by universities worldwide (free).
 - **[Stat Trek](https://stattrek.com)** - Free tutorials, calculators, and video lessons for AP Statistics (free).
+- **[Statistics Calculator](https://nutilz.com/statistics-calculator)** - Free calculator for mean, median, mode, standard deviation, and quartiles (free).
 - **[StatQuest with Josh Starmer](https://www.youtube.com/c/joshstarmer)** - Clear, visual explanations of statistics and machine learning concepts (free).
 
 </details>


### PR DESCRIPTION
Adds [Statistics Calculator](https://nutilz.com/statistics-calculator) to the By Subject > Statistics section, alphabetized between Stat Trek and StatQuest.

It helps students get free mean/median/mode/standard-deviation/quartile results from a raw list of numbers without signing up, useful for checking AP Statistics or intro-stats homework by hand quickly.

Updated the resources count badge (193 -> 194) and the By Subject row in the Table of Contents (71 -> 72) per CONTRIBUTING.md, since `node` was not available in this environment to run `scripts/update-counts.mjs` directly -- happy to fix if the numbers do not match what the script would produce.