### PR TITLE
Point resource_suggestion template at an existing label

### DIFF
--- a/.github/ISSUE_TEMPLATE/resource_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/resource_suggestion.yml
@@ -1,6 +1,6 @@
 name: Suggest a resource
 description: Suggest a tool, channel, or book to add (if you're not opening a PR yourself)
-labels: ["resource"]
+labels: ["content"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Closes #30.

## Resources

Not a resource PR. The resource fields below are N/A.

- Link: N/A
  Why it helps students: N/A

## What this changes

`.github/ISSUE_TEMPLATE/resource_suggestion.yml` set `labels: ["resource"]`. There is no `resource` label in this repo, and GitHub silently drops unknown label references instead of erroring, so every issue filed through that form arrived with no label at all.

Switched to `content`, which exists and is described as "List entries and sections" - the closest fit, and the option the issue suggested.

Verified with `gh label list --repo StudentSuite/awesome-study-resources`: `content` is present, `resource` is not. The other two templates already reference real labels (`bug`, `enhancement`).

## Checklist

- [x] Each entry added in the correct section, in alphabetical order (case-insensitive) - N/A, no README entry
- [x] Each entry follows the format from [CONTRIBUTING.md](../CONTRIBUTING.md) - N/A, no README entry
- [x] Each entry meets the [Quality Standards](../README.md#quality-standards) - N/A, no README entry
- [x] No entry duplicates an existing one in the same section - N/A, no README entry

## Note

While checking this I also looked at #32 (`create-issue-from-file` pinned to two majors). Both `dead-link-check.yml` and `pricing-review.yml` are already on `@v6` on `main` - Dependabot bumped `pricing-review.yml` in f573df3. That issue looks closeable as-is.
