### PR TITLE
Add MyRevisionAgent to IB (IBDP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-304-blue)
+![Resources](https://img.shields.io/badge/resources-305-blue)
 ![Sections](https://img.shields.io/badge/sections-11-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v1.0.0-blue.svg)](CHANGELOG.md)
 
@@ -31,7 +31,7 @@ This is a curation list, not a code library. Every entry links out to a tool, ch
 
 | | Section | Resources |
 | :-: | --- | :-: |
-| <span role="img" aria-label="Exam and Curriculum Prep icon">📝</span> | [Exam & Curriculum Prep](#exam--curriculum-prep) | 74 |
+| <span role="img" aria-label="Exam and Curriculum Prep icon">📝</span> | [Exam & Curriculum Prep](#exam--curriculum-prep) | 75 |
 | <span role="img" aria-label="By Subject icon">📚</span> | [By Subject](#by-subject) | 154 |
 | <span role="img" aria-label="Notes and Knowledge Management icon">🗒️</span> | [Notes & Knowledge Management](#notes--knowledge-management) | 6 |
 | <span role="img" aria-label="Flashcards and Spaced Repetition icon">🧠</span> | [Flashcards & Spaced Repetition](#flashcards--spaced-repetition) | 5 |
@@ -155,6 +155,7 @@ Official and community prep for the big exams and curricula.
 <summary>Show resources</summary>
 
 - **[IB Documents](https://www.ibdocuments.com/)** - Free archive of IB past papers and resources (free).
+- **[MyRevisionAgent](https://myrevisionagent.com)** - Grades TOK essays, Extended Essays, and IAs against official IB rubrics (freemium).
 - **[Nail IB](https://nailib.com)** - Examiner-led videos, past papers, and question banks for the IB Diploma (freemium).
 - **[Revision Village](https://www.revisionvillage.com)** - Video lessons and worked past papers built around the IB Math syllabus (freemium).
 - **[RevisionDojo](https://www.revisiondojo.com)** - Practice questions and study tools built around the IB syllabus (freemium).


### PR DESCRIPTION
Adding one entry to **IB (IBDP)**.

- **[MyRevisionAgent](https://myrevisionagent.com)** - Grades TOK essays, Extended Essays, and IAs against official IB rubrics (freemium).

A student uploads a TOK essay, Extended Essay or Internal Assessment and gets a predicted grade against the official rubric, with per-criterion feedback highlighted on their own PDF. It marks work the student has already written rather than generating anything.

Placed in IB (IBDP) rather than the Extended Essay or Theory of Knowledge sections because it covers all three plus Internal Assessments, so a single bullet in the broader section seemed the better fit. Happy to move it if you would rather it sat elsewhere.

**Pricing:** tagged `(freemium)`. New accounts get signup tokens that cover the first grade with no card; after that it is pay-as-you-go token packs from £9.99, no subscription.

### Checklist

- [x] Free, freemium, or clearly worth the price, with the pricing noted
- [x] A reputable tool, not spam or an affiliate funnel
- [x] Single bullet, in the closest matching section
- [x] Correct alphabetical position (between IB Documents and Nail IB)
- [x] Description is one line, no banned adjectives, no em dashes
- [x] Counts regenerated with `scripts/update-counts.mjs`
- [x] `scripts/check-list-format.mjs` passes locally

Disclosure: I am the maintainer of this tool.