### PR TITLE
add Khan Academy Chemistry to the Chemistry subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-305-blue)
+![Resources](https://img.shields.io/badge/resources-306-blue)
 ![Sections](https://img.shields.io/badge/sections-11-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v1.0.0-blue.svg)](CHANGELOG.md)
 
@@ -32,7 +32,7 @@ This is a curation list, not a code library. Every entry links out to a tool, ch
 | | Section | Resources |
 | :-: | --- | :-: |
 | <span role="img" aria-label="Exam and Curriculum Prep icon">📝</span> | [Exam & Curriculum Prep](#exam--curriculum-prep) | 75 |
-| <span role="img" aria-label="By Subject icon">📚</span> | [By Subject](#by-subject) | 154 |
+| <span role="img" aria-label="By Subject icon">📚</span> | [By Subject](#by-subject) | 155 |
 | <span role="img" aria-label="Notes and Knowledge Management icon">🗒️</span> | [Notes & Knowledge Management](#notes--knowledge-management) | 6 |
 | <span role="img" aria-label="Flashcards and Spaced Repetition icon">🧠</span> | [Flashcards & Spaced Repetition](#flashcards--spaced-repetition) | 5 |
 | <span role="img" aria-label="Task, Time and Planning icon">⏰</span> | [Task, Time & Planning](#task-time--planning) | 5 |
@@ -286,6 +286,7 @@ Flagship picks per subject: mix a strong site, a channel, and a practice tool.
 
 - **[Chemguide](https://www.chemguide.co.uk)** - Focused explanations for UK A-Level and IGCSE chemistry (free).
 - **[Chemistry LibreTexts](https://chem.libretexts.org)** - Free, open chemistry textbooks and reference material (free).
+- **[Khan Academy Chemistry](https://www.khanacademy.org/science/chemistry)** - Free lessons and practice across the chemistry syllabus (free).
 - **[Master Organic Chemistry](https://www.masterorganicchemistry.com)** - Clear guides and cheat sheets for organic chemistry (freemium).
 - **[The Organic Chemistry Tutor](https://www.youtube.com/@TheOrganicChemistryTutor)** - Step-by-step worked problems across chemistry and beyond (freemium).
 


### PR DESCRIPTION
Add Khan Academy Chemistry to the Chemistry subsection

Chemistry only had 4 entries; adds the same Khan Academy per-subject
resource already used for Biology, Statistics, etc. Partial progress on #116
(issue asks for 2-3 more; this adds one).
