### PR TITLE
Add resource: 1600.now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ v1.0.0 tag itself.
 
 ### Added
 
+- [1600.now](https://1600.now/) in Exam & Curriculum Prep / SAT for free
+  practice questions, timed tests, and answer explanations.
 - [IELTS Writing Checker](https://ieltswritingchecker.org/) in Writing,
   Citations & Reference for IELTS Task 1 and Task 2 criterion feedback (#105).
 - A `### Philosophy` subsection under By Subject, with 3 vetted entries

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-344-blue)
+![Resources](https://img.shields.io/badge/resources-345-blue)
 ![Sections](https://img.shields.io/badge/sections-11-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v1.0.0-blue.svg)](CHANGELOG.md)
 
@@ -31,7 +31,7 @@ This is a curation list, not a code library. Every entry links out to a tool, ch
 
 | | Section | Resources |
 | :-: | --- | :-: |
-| <span role="img" aria-label="Exam and Curriculum Prep icon">📝</span> | [Exam & Curriculum Prep](#exam--curriculum-prep) | 76 |
+| <span role="img" aria-label="Exam and Curriculum Prep icon">📝</span> | [Exam & Curriculum Prep](#exam--curriculum-prep) | 77 |
 | <span role="img" aria-label="By Subject icon">📚</span> | [By Subject](#by-subject) | 184 |
 | <span role="img" aria-label="Notes and Knowledge Management icon">🗒️</span> | [Notes & Knowledge Management](#notes--knowledge-management) | 8 |
 | <span role="img" aria-label="Flashcards and Spaced Repetition icon">🧠</span> | [Flashcards & Spaced Repetition](#flashcards--spaced-repetition) | 7 |
@@ -200,6 +200,7 @@ Official and community prep for the big exams and curricula.
 <summary>Show resources</summary>
 
 - **[1600.io](https://1600.io)** - Deep video courses and problem sets for serious SAT scores (paid).
+- **[1600.now](https://1600.now/)** - Practice SAT questions and timed tests with answer explanations (free).
 - **[College Board Bluebook](https://bluebook.collegeboard.org)** - The official app that delivers full-length adaptive practice tests (free).
 - **[Khan Academy Official Digital SAT](https://www.khanacademy.org/digital-sat)** - Free official Digital SAT practice, made with College Board (free).
 - **[Magoosh SAT](https://sat.magoosh.com)** - Video lessons and practice questions for the Digital SAT (freemium).

--- a/data/resources.json
+++ b/data/resources.json
@@ -2406,5 +2406,12 @@
     "description": "Landmark physics text, free to read online (free).",
     "section": "Great Textbooks",
     "subsection": null
+  },
+  {
+    "name": "1600.now",
+    "url": "https://1600.now/",
+    "description": "Practice SAT questions and timed tests with answer explanations (free).",
+    "section": "Exam & Curriculum Prep",
+    "subsection": "SAT"
   }
 ]


### PR DESCRIPTION
## Resources

- Link: https://1600.now/
  Why it helps students: Students can practice SAT questions by skill, review answer explanations, and take timed tests for free without a required account.

Disclosure: I’m the creator of 1600.now. This adds one entry under Exam & Curriculum Prep / SAT, regenerates the README, and records the addition in the changelog.

## Checklist

- [x] Entry added in the correct section and alphabetized by the generator
- [x] Entry follows the format in CONTRIBUTING.md
- [x] Resource is live and maintained, with free pricing stated and a direct link
- [x] No duplicate entry in the SAT section or existing PR for 1600.now found

## Validation

- `node scripts/validate-resources.mjs`
- `node scripts/generate-readme.mjs --check`
- `node scripts/check-list-format.mjs`
- `node scripts/update-counts.mjs --check`
- `git diff --check`
